### PR TITLE
New bool config option `AMQPDisable` to disable AMQP processing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8 as builder
+FROM golang:1.9 as builder
 
 RUN apt-get update && apt-get install -y libprotobuf-java protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
@@ -14,7 +14,7 @@ RUN export GOPATH=/go && \
     go get ./... && \
     go build
 
-FROM golang:1.8
+FROM golang:1.9
 WORKDIR /
 COPY --from=builder /go/bin/cb-event-forwarder .
 COPY --from=builder /go/src/github.com/carbonblack/cb-event-forwarder/conf .

--- a/main.go
+++ b/main.go
@@ -596,6 +596,10 @@ func main() {
 		queueName = config.AMQPQueueName
 	}
 
+	if config.AMQPDisabled {
+		numConsumers = 0
+		log.Infof("AMQP processing is disabled, not starting AMQP processing loop")
+	}
 	for i := 0; i < numConsumers; i++ {
 		go func(consumerNumber int) {
 			log.Infof("Starting AMQP loop %d to %s on queue %s", consumerNumber, config.AMQPURL(), queueName)


### PR DESCRIPTION
This will allow audit log processing without affecting a separate Rabbit MQ event forwarder.

Todo after merge - 

[ ] - Figure out how and where to build the updated code
[ ] - Test this new code to ensure it works as expected
[ ] - generate an RPM file with this updated code, to replace https://github.com/redcanaryco/puppet/blob/master/modules/cb_event_forwarder/files/cb-event-forwarder.rpm
[ ] - Update puppet configs to cleanly separate the telemetry forwarder from the audit log forwarder, and provide the ability on a per-server basis to enable/disable either service from running locally
