### PR TITLE
fix delete secret namespace, add repo template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ policy in https://drive.google.com/drive/folders/1YgEceW5HQ2bQ4OAuhFIgN1oHmLk9Rf
 - [ ] None: Documentation change
 - [ ] Unit Tests
 - [ ] Functional Tests
-- [X] Manual Tests
+- [X] Manual Tests: <!-- Describe how this should be tested -->
 
 <!--
 Describe the testing procedure that has been done, or will be done, if any.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,10 +52,10 @@ the following default should suffice.
 ### Approvals Needed
 
 Routine Changes:
- - @redcanaryco/team-sre or @@redcanaryco/team-processing (Optional)
+ - @redcanaryco/team-sre or @redcanaryco/team-processing (Optional)
 
 Declared Changes:
- - @redcanaryco/team-sre and @@redcanaryco/team-processing (Required Prior to Merge)
+ - @redcanaryco/team-sre and @redcanaryco/team-processing (Required Prior to Merge)
 
 Emergency Changes:
- - @redcanaryco/team-sre and @@redcanaryco/team-processing (Required Prior/Post Merge)
+ - @redcanaryco/team-sre and @redcanaryco/team-processing (Required Prior/Post Merge)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,8 +31,8 @@ Optional for routine changes, mandatory for declared changes.
 ### Rollout Procedure
 
 - [ ] None: Non-configuration management change
-- [ ] Manual Roll-Out: <!-- If checked, replace with description -->
-- [X] Automated Roll-Out (Full): Changes will be applied when an image is built from master and pushed to redcanary/cb-event-forwarder:latest
+- [X] Manual Roll-Out: <!-- If checked, replace with description -->
+- [ ] Automated Roll-Out (Full)
 
 <!--
 Describe how this change will be rolled out. For most changes in this repository,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,61 @@
+### Description
+
+<!--
+A description of the change in this PR.
+Place a reference to the Github issue or the PagerDuty incident, if any, here.
+-->
+
+### Type of Change
+
+- [X] Routine: low risk change
+- [ ] Declared: a significant or high risk change
+- [ ] Emergency: a change made to fix an on-going incident
+
+<!--
+Classify this change as one of the following, according to the change management
+policy in https://drive.google.com/drive/folders/1YgEceW5HQ2bQ4OAuhFIgN1oHmLk9RfTV
+-->
+
+### Testing
+
+- [ ] None: Implicit through tooling or non-configuration management change
+- [ ] Unit Tests
+- [ ] Functional Tests
+- [X] Manual Tests
+
+<!--
+Describe the testing procedure that has been done, or will be done, if any.
+Optional for routine changes, mandatory for declared changes.
+-->
+
+### Rollout Procedure
+
+- [ ] None: Non-configuration management change
+- [ ] Manual Roll-Out: <!-- If checked, replace with description -->
+- [X] Automated Roll-Out (Full): Changes will be applied when an image is built from master and pushed to redcanary/cb-event-forwarder:latest
+
+<!--
+Describe how this change will be rolled out. For most changes in this repository,
+the following default should suffice.
+-->
+
+### Rollback Procedure
+
+Reverting the merge of this PR, and applying the rollout procedure above, will roll
+back the changes in this PR.
+
+<!--
+Describe how this change will be rolled back. For most changes in this repository,
+the following default should suffice.
+-->
+
+### Approvals Needed
+
+Routine Changes:
+ - @redcanaryco/team-sre or @@redcanaryco/team-processing (Optional)
+
+Declared Changes:
+ - @redcanaryco/team-sre and @@redcanaryco/team-processing (Required Prior to Merge)
+
+Emergency Changes:
+ - @redcanaryco/team-sre and @@redcanaryco/team-processing (Required Prior/Post Merge)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ policy in https://drive.google.com/drive/folders/1YgEceW5HQ2bQ4OAuhFIgN1oHmLk9Rf
 
 ### Testing
 
-- [ ] None: Implicit through tooling or non-configuration management change
+- [ ] None: Documentation change
 - [ ] Unit Tests
 - [ ] Functional Tests
 - [X] Manual Tests

--- a/deploy/deploy_event_forwarder.sh
+++ b/deploy/deploy_event_forwarder.sh
@@ -87,7 +87,7 @@ sed -i -e "s,@@DESTINATION_S3_REGION@@,us-east-1," "${TMPFILE}"
 sed -i -e "s,@@DESTINATION_S3_BUCKET@@,rc-native," "${TMPFILE}"
 sed -i -e "s,@@CB_RABBIT_SSL@@,${CB_RABBIT_SSL}," "${TMPFILE}"
 
-cmd="kubectl delete secret "${CUSTOMER_NAME}-event-forwarder-config""
+cmd="kubectl delete secret "${CUSTOMER_NAME}-event-forwarder-config" -n ${NAMESPACE}"
 echo $cmd
 $cmd || true
 


### PR DESCRIPTION
### Description
Not having the namespace in the first kubectl secret check, caused the script to exit prematurely. This should resolve this issue, which occurred where the secret existed already the deployment was being updated.  This change only affects the scripts that creates a new forwarder deployment it will not impact any existing forwarders. 

Added a template similar to other repo's templates.  Would appreciate feedback on the Rollout procedure section, I'm not sure how often the docker image gets updated for this.  

<!--
A description of the change in this PR.
Place a reference to the Github issue or the PagerDuty incident, if any, here.
-->

### Type of Change

- [X] Routine: low risk change. While I would consider the change to the script routine, I think the template should be reviewed by someone other than myself. 
- [ ] Declared: a significant or high risk change
- [ ] Emergency: a change made to fix an on-going incident

<!--
Classify this change as one of the following, according to the change management
policy in https://drive.google.com/drive/folders/1YgEceW5HQ2bQ4OAuhFIgN1oHmLk9RfTV
-->

### Testing

- [ ] None: Implicit through tooling or non-configuration management change
- [ ] Unit Tests
- [ ] Functional Tests
- [X] Manual Tests - tested locally on a test cb server forwarder

<!--
Describe the testing procedure that has been done, or will be done, if any.
Optional for routine changes, mandatory for declared changes.
-->

### Rollout Procedure

- [x] None: Non-configuration management change
- [ ] Manual Roll-Out: <!-- If checked, replace with description -->
- [ ] Automated Roll-Out (Full): Changes will be applied when an image is built from master and pushed to redcanary/cb-event-forwarder:latest

<!--
Describe how this change will be rolled out. For most changes in this repository,
the following default should suffice.
-->

### Rollback Procedure

Reverting the merge of this PR, and applying the rollout procedure above, will roll
back the changes in this PR.

<!--
Describe how this change will be rolled back. For most changes in this repository,
the following default should suffice.
-->

### Approvals Needed

Routine Changes:
 - @redcanaryco/team-sre or @redcanaryco/team-processing (Optional)

Declared Changes:
 - @redcanaryco/team-sre and @redcanaryco/team-processing (Required Prior to Merge)

Emergency Changes:
 - @redcanaryco/team-sre and @redcanaryco/team-processing (Required Prior/Post Merge)