### PR TITLE
Prometheus Metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/carbonblack/cb-event-forwarder/sensor_events"
 	"github.com/pborman/uuid"
 	"github.com/streadway/amqp"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 import _ "net/http/pprof"
@@ -541,6 +543,8 @@ func main() {
 			break
 		}
 	}
+
+	http.Handle("/metrics/", promhttp.Handler())
 
 	if *debug {
 		http.HandleFunc("/debug/sendmessage", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Part of https://github.com/redcanaryco/infrastructure/issues/220

This PR adds some basic Prometheus instrumentation to our fork of the CB event forwarder.

This has been tested by running the event forwarder with these hooks against an RC-internal test server, and confirming that it successfully collects the metrics that are added in here.

To deploy this change, a new build of the event forwarder will need to be sent to DockerHub, and deployed in another PR in our Saltstack repository to the CB servers that are running the event forwarder on the same box. Other infrastructure changes will need to be made in order to make use of this change.